### PR TITLE
Normalise gateway.conf controls on startup

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -374,6 +374,24 @@ class Config(object):
     def commit(self, post_action='close'):
         self._commit_rbd(post_action)
 
+    def normalise_controls(self):
+        changed = False
+        for section in ('targets', 'disks', 'gateways'):
+            for item in self.config.get(section, {}).keys():
+                item_changed = False
+                if 'controls' not in self.config[section].get(item, {}):
+                    continue
+                for c_key, c_value in self.config[section][item]['controls'].items():
+                    if isinstance(c_value, str):
+                        if c_value.isdigit():
+                            self.config[section][item]['controls'][c_key] = int(c_value)
+                            item_changed = True
+                if item_changed:
+                    self.set_item(section, item, self.config[section][item])
+                    changed = True
+        if changed:
+            self.commit('retain')
+
 
 def ansible_control():
     """

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -1980,6 +1980,9 @@ def main():
     log.addHandler(file_handler)
     log.addHandler(syslog_handler)
 
+    # normalise controls in case upgrade has left some ints as strings
+    config.normalise_controls()
+
     if settings.config.api_secure:
 
         context = get_ssl_context()


### PR DESCRIPTION
There is a chance that an ses5.5 - 6 upgrade incorrectly stored int
values in the config as strings, and this can lead dashboard issues if
you want to make chances.

This patch will take a look at the config at startup, once it's loaded
from the rados pool, and if there is any ints stored as strings will
write correct them and write it back to the config on the pool.

Signed-off-by: Matthew Oliver <moliver@suse.com>