### PR TITLE
Normalise gateway.conf controls on startup

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2844,6 +2844,9 @@ def main():
     log.addHandler(file_handler)
     log.addHandler(syslog_handler)
 
+    # normalise controls in case upgrade has left some ints as strings
+    config.normalise_controls()
+
     ceph_gw = CephiSCSIGateway(logger, config)
 
     osd_state_ok = ceph_gw.osd_blacklist_cleanup()


### PR DESCRIPTION
here is a chance that an ses5.5 - 6 upgrade incorrectly stored int
values in the config as strings, and this can lead dashboard issues if
you want to make chances.

This patch will take a look at the config at startup, once it's loaded
from the rados pool, and if there is any ints stored as strings will
write correct them and write it back to the config on the pool.

Signed-off-by: Matthew Oliver <moliver@suse.com>