### PR TITLE
ceph_iscsi_config: disable emulate_legacy_capacity 

### DIFF
--- a/ceph_iscsi_config/gateway_setting.py
+++ b/ceph_iscsi_config/gateway_setting.py
@@ -225,6 +225,7 @@ KERNEL_SETTINGS = {
     "emulate_dpo": EnumSetting("emulate_dpo", [0, 1], 1),
     "emulate_fua_read": EnumSetting("emulate_fua_read", [0, 1], 1),
     "emulate_fua_write": EnumSetting("emulate_fua_write", [0, 1], 1),
+    "emulate_legacy_capacity": EnumSetting("emulate_legacy_capacity", [0, 1], 1),
     "emulate_model_alias": EnumSetting("emulate_model_alias", [0, 1], 0),
     "emulate_pr": EnumSetting("emulate_pr", [0, 1], 1),
     "emulate_rest_reord": EnumSetting("emulate_rest_reord", [0, 1], 1),


### PR DESCRIPTION
if the corresponding control is set.

The controls are applied after enabling the backstore, and in the
case of emulate_legacy_capacity control it is too late, as it is
checked by the backend on enabling. Thus we need to provide this
setting earlier.

Note, this requires a version of rtslib that supports
disable_emulate_legacy_capacity param.

Signed-off-by: Mykola Golub <mgolub@suse.com>